### PR TITLE
fix: sync with replicaset config

### DIFF
--- a/le-taxi-api-node.js/config/acceptation.yaml
+++ b/le-taxi-api-node.js/config/acceptation.yaml
@@ -20,6 +20,7 @@ dataSources:
   mongo:
     host1: acclgt01a.ile.montreal.qc.ca
     host2: acclgt01b.ile.montreal.qc.ca
+    host3: acclgt01c.ile.montreal.qc.ca
 
 #==========================================
 # Routing Service OSRM

--- a/le-taxi-api-node.js/config/default.yaml
+++ b/le-taxi-api-node.js/config/default.yaml
@@ -70,6 +70,7 @@ dataSources:
   mongo:
     host1: dvllgt01a.ile.montreal.qc.ca
     host2: dvllgt01b.ile.montreal.qc.ca
+    host3: dvllgt01c.ile.montreal.qc.ca
     port: 27001
     defaultauthdb: vdm_txp
     username:

--- a/le-taxi-api-node.js/config/development.yaml
+++ b/le-taxi-api-node.js/config/development.yaml
@@ -17,6 +17,7 @@ dataSources:
   mongo:
     host1: dvllgt01a.ile.montreal.qc.ca
     host2: dvllgt01b.ile.montreal.qc.ca
+    host3: dvllgt01c.ile.montreal.qc.ca
 caching:
   taxisMaxAgeInSec: 10
   usersMaxAgeInSec: 10

--- a/le-taxi-api-node.js/config/production.yaml
+++ b/le-taxi-api-node.js/config/production.yaml
@@ -20,6 +20,7 @@ dataSources:
   mongo:
     host1: prdlgt01a.ile.montreal.qc.ca
     host2: prdlgt01b.ile.montreal.qc.ca
+    host3: prdlgt01c.ile.montreal.qc.ca
 
 #==========================================
 # Routing Service OSRM

--- a/le-taxi-api-node.js/src/config/configs.ts
+++ b/le-taxi-api-node.js/src/config/configs.ts
@@ -189,6 +189,7 @@ export class Configs {
       mongo: {
         host1: this.cache.get<string>('dataSources.mongo.host1'),
         host2: this.cache.get<string>('dataSources.mongo.host2'),
+        host3: this.cache.get<string>('dataSources.mongo.host3'),
         port: this.cache.get<number>('dataSources.mongo.port'),
         username: this.cache.get<string>('dataSources.mongo.username'),
         password: this.cache.get<string>('dataSources.mongo.password'),

--- a/le-taxi-api-node.js/src/features/shared/taxiMongo/taxiMongo.ts
+++ b/le-taxi-api-node.js/src/features/shared/taxiMongo/taxiMongo.ts
@@ -18,8 +18,8 @@ export async function connectToMongoDb() {
 }
 
 function buildMongoConnectionString(): string {
-  const { host1, host2, port, username, password, defaultauthdb, options } = configs.dataSources.mongo;
-  return `mongodb://${username}:${password}@${host1}:${port},${host2}:${port}/${defaultauthdb}?${options}`;
+  const { host1, host2, host3, port, username, password, defaultauthdb, options } = configs.dataSources.mongo;
+  return `mongodb://${username}:${password}@${host1}:${port},${host2}:${port},${host3}:${port}/${defaultauthdb}?${options}`;
 }
 
 export function getMongoDb() {


### PR DESCRIPTION
It is recommended to use members defined in replicaset config see: https://www.mongodb.com/docs/manual/reference/connection-string/#replica-set-with-members-on-different-machines

Signed-off-by: Daniel Brodeur <daniel.brodeur@montreal.ca>