### PR TITLE
fix: change map provider (stamen shutdown)

### DIFF
--- a/le-taxi-ui-angular/src/app/shared/map/layer.ts
+++ b/le-taxi-ui-angular/src/app/shared/map/layer.ts
@@ -5,11 +5,11 @@ declare var L: any;
 
 export function getStamenTonerLayer() {
   return L.tileLayer(
-    'https://stamen-tiles-{s}.a.ssl.fastly.net/toner/{z}/{x}/{y}{r}.{ext}',
+    'https://tiles.stadiamaps.com/tiles/stamen_toner/{z}/{x}/{y}{r}.{ext}',
     {
       attribution:
         // tslint:disable-next-line:max-line-length
-        'Map tiles by <a href="http://stamen.com">Stamen Design</a>, <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a> &mdash; Map data &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+        '&copy; <a href="https://stadiamaps.com/" target="_blank">Stadia Maps</a> <a href="https://stamen.com/" target="_blank">&copy; Stamen Design</a> &copy; <a href="https://openmaptiles.org/" target="_blank">OpenMapTiles</a> &copy; <a href="https://www.openstreetmap.org/about" target="_blank">OpenStreetMap</a> contributors',
       subdomains: 'abcd',
       minZoom: 0,
       maxZoom: 20,


### PR DESCRIPTION
Stamen Maps no longer serving tiles by their own. See: https://stamen.com/here-comes-the-future-of-stamen-maps/

onboarding has been done [here](https://docs.stadiamaps.com/guides/migrating-from-stamen-map-tiles/) using the support email. Therefore, our domain has been whitelisted so that the tile can be fetched again with the new url provided by stadia.

Only concern for me is this [line](https://github.com/VilledeMontreal/montreal-taxi-registry/blob/9de6dc656b1604e54878c6b1a9c17f6d3bb0c584/le-taxi-ui-angular/src/index.html#L20). 
Maybe we should move this to our asset folder to ensure it will not go offline too...

No error handling is done for now when limit is reached.