### PR TITLE
fix: gofs-lite compliance

### DIFF
--- a/le-taxi-api-node.js/src/features/gofsLite/gofsLite.constants.ts
+++ b/le-taxi-api-node.js/src/features/gofsLite/gofsLite.constants.ts
@@ -49,11 +49,11 @@ export function zonesFunc(lang: GofsLiteSupportedLangTypes): GofsLiteZoneRespons
 
 function patchLocationsInEnglish(locations: FeatureCollection): FeatureCollection {
   const locationsEn = _.cloneDeep(locations);
-  locationsEn.features[0].properties.stop_name = 'Montréal-Trudeau International Airport';
-  locationsEn.features[0].properties.stop_desc =
+  locationsEn.features[0].properties.name = 'Montréal-Trudeau International Airport';
+  locationsEn.features[0].properties.description =
     'The airport is subject to federal jurisdiction that prevents the Taxi Registry to honour ride request from the airport';
-  locationsEn.features[1].properties.stop_name = 'Jurisdiction of the Autorité régionale de transport métropolitain';
-  locationsEn.features[1].properties.stop_desc = `Longueuil Urban Area, Beauharnois-Salaberry MRC, Deux-Montagnes MRC, L'Assomption MRC, Rivière-du-Nord MRC, Vallée-du-Richelieu MRC, Moulins MRC, Marguerite-D'Youville MRC, Roussillon MRC, Rouville MRC, Thérèse-De Blainville MRC, Vaudreuil-Soulanges MRC, City of Laval, City of Mirabel.`;
+  locationsEn.features[1].properties.name = 'Jurisdiction of the Autorité régionale de transport métropolitain';
+  locationsEn.features[1].properties.description = `Longueuil Urban Area, Beauharnois-Salaberry MRC, Deux-Montagnes MRC, L'Assomption MRC, Rivière-du-Nord MRC, Vallée-du-Richelieu MRC, Moulins MRC, Marguerite-D'Youville MRC, Roussillon MRC, Rouville MRC, Thérèse-De Blainville MRC, Vaudreuil-Soulanges MRC, City of Laval, City of Mirabel.`;
   return locationsEn;
 }
 

--- a/le-taxi-api-node.js/src/features/gofsLite/gofsLite.controller.ts
+++ b/le-taxi-api-node.js/src/features/gofsLite/gofsLite.controller.ts
@@ -78,7 +78,7 @@ class GofsLiteController {
 
 function buildFeed(feeds: string[], lang: string): GofsLiteFeedDetailResponseDto[] {
   return feeds.map(feed => ({
-    name: feed.substring(feed.lastIndexOf('/') + 1),
+    name: feed.substring(feed.lastIndexOf('/') + 1).replace('.json', ''),
     url: getAbsoluteUrl(feed.replace(':lang', lang))
   }));
 }

--- a/le-taxi-api-node.js/src/features/shared/locations/locations.json
+++ b/le-taxi-api-node.js/src/features/shared/locations/locations.json
@@ -4,9 +4,10 @@
     {
       "type": "Feature",
       "id": "airport",
+      "zone_id": "airport",
       "properties": {
-        "stop_name": "Aéroport International Montréal-Trudeau",
-        "stop_desc": "L'aéroport est assujeti à la juridiction fédérale qui ne permet pas d'utiliser le Registre des taxis, afin de demander une course à partir de l'aéroport."
+        "name": "Aéroport International Montréal-Trudeau",
+        "description": "L'aéroport est assujeti à la juridiction fédérale qui ne permet pas d'utiliser le Registre des taxis, afin de demander une course à partir de l'aéroport."
       },
       "geometry": {
         "type": "Polygon",
@@ -71,9 +72,10 @@
     {
       "type": "Feature",
       "id": "artm",
+      "zone_id": "artm",
       "properties": {
-        "stop_name": "Territoire de l'Autorité régionale de transport métropolitain",
-        "stop_desc": "Agglomération de Longueuil, MRC de Beauharnois-Salaberry, MRC de Deux-Montagnes, MRC de L'Assomption, MRC de La Rivière-du-Nord, MRC de La Vallée-du-Richelieu, MRC des Moulins, MRC de Marguerite-D'Youville, MRC de Roussillon, MRC de Rouville, MRC de Thérèse-De Blainville, MRC de Vaudreuil-Soulanges, Ville de Laval, Ville de Mirabel."
+        "name": "Territoire de l'Autorité régionale de transport métropolitain",
+        "description": "Agglomération de Longueuil, MRC de Beauharnois-Salaberry, MRC de Deux-Montagnes, MRC de L'Assomption, MRC de La Rivière-du-Nord, MRC de La Vallée-du-Richelieu, MRC des Moulins, MRC de Marguerite-D'Youville, MRC de Roussillon, MRC de Rouville, MRC de Thérèse-De Blainville, MRC de Vaudreuil-Soulanges, Ville de Laval, Ville de Mirabel."
       },
       "geometry": {
         "type": "Polygon",

--- a/le-taxi-api-tests/src/gofsLite/crudGofsLite.apiTest.ts
+++ b/le-taxi-api-tests/src/gofsLite/crudGofsLite.apiTest.ts
@@ -21,9 +21,23 @@ import {
 
 // tslint:disable: max-func-body-length
 export async function crudGofsLiteTests(): Promise<void> {
-  it(`Should be able to request GOFS feed`, async () => {
+  it(`Should be able to request GOFS feed with expected payload`, async () => {
     const response = await getFeed();
     assert.strictEqual(response.status, StatusCodes.OK);
+    assert.nestedProperty(response.body, 'data.en.feeds');
+    assert.nestedProperty(response.body, 'data.fr.feeds');
+
+    const feedsEn: any[] = response.body.data.en.feeds;
+    feedsEn.forEach(feed => {
+      assert.exists(feed?.name);
+      assert.notMatch(feed.name, /\.json$/, 'name should not end with .json extension');
+    });
+
+    const feedsFr: any[] = response.body.data.fr.feeds;
+    feedsFr.forEach(feed => {
+      assert.exists(feed?.name);
+      assert.notMatch(feed.name, /\.json$/, 'name should not end with .json extension');
+    });
   });
 
   it(`Should be able to request GOFS realtime_booking`, async () => {
@@ -51,9 +65,27 @@ export async function crudGofsLiteTests(): Promise<void> {
     assert.strictEqual(response.status, StatusCodes.OK);
   });
 
-  it(`Should be able to request GOFS zones`, async () => {
+  it(`Should be able to request GOFS zones with expected payload`, async () => {
     const response = await getZones();
     assert.strictEqual(response.status, StatusCodes.OK);
+
+    assert.nestedProperty(response.body, 'data.zones.features');
+
+    const features = response.body.data.zones.features;
+    assert.isAbove(features?.length, 0);
+
+    features.forEach((feature: any) => {
+      assert.exists(feature?.id);
+      assert.exists(feature?.zone_id);
+      assert.strictEqual(feature.zone_id, feature.id);
+
+      assert.exists(feature?.properties);
+      assert.nestedProperty(feature, 'properties.name');
+      assert.nestedProperty(feature, 'properties.description');
+
+      assert.notNestedProperty(feature, 'properties.stop_name');
+      assert.notNestedProperty(feature, 'properties.stop_desc');
+    });
   });
 
   it(`Should be able to request GOFS operating rules`, async () => {


### PR DESCRIPTION
- For /api/gofs-lite, `data.(en|fr).feeds[].name` properties values should not end with `.json`
- For /api/gofs-lite/1/(en|fr)/zones.json, add some missing properties:
    - `data.zones.features[].zone_id`
    - `data.zones.features[].properties.name` (renamed from stop_name)
    - `data.zones.features[].properties.description` (renamed from stop_desc)
 