### PR TITLE
fix: bad coord for airport TM-1830

### DIFF
--- a/le-taxi-api-node.js/src/features/gtfs/deepLinks/gtfsDeepLinks.templates.ts
+++ b/le-taxi-api-node.js/src/features/gtfs/deepLinks/gtfsDeepLinks.templates.ts
@@ -10,7 +10,7 @@ const eightyQueen = {
   address: '80 Queen, Montréal, QC H3C 6X4'
 };
 const cityHall = { lat: 45.50891801, lon: -73.554333425, address: 'City Hall' };
-const airport = { lat: 45.465683693, lon: -73.74548144, address: 'Airport' };
+const airport = { lat: 45.457773, lon: -73.748345, address: 'Airport departure' };
 const oldLongueuil = {
   lat: 45.538120632,
   lon: -73.51005992,


### PR DESCRIPTION
Previous coords was off (business related to aircraft while expecting airport departure/arrival zone)

Using 6 digits in long/lat is sufficient enough (precision of 11 cm) see https://support.garmin.com/en-US/?faq=hRMBoCTy5a7HqVkxukhHd8 :
<img width="722" alt="image" src="https://github.com/user-attachments/assets/856e1302-f864-46d2-972b-d95bf9ba5700" />
